### PR TITLE
Fixes stack issue in #15

### DIFF
--- a/codebuild-ci.yaml
+++ b/codebuild-ci.yaml
@@ -5,6 +5,9 @@ Parameters:
   GitHubRepositoryName:
     Type: String
     Description: GitHub Repo Name For aws-cloudformation-resource-providers-ses
+  GitHubRepositoryShortName:
+    Type: String
+    Description: Short Name for this provider to avoid exceeding the 64char limit on IAM Resources
   CFNSDKBucket:
     Type: String
     Description: S3 Location of CloudFormation SDK; should be removed when we can publish the latest client
@@ -40,7 +43,7 @@ Resources:
   AWSCloudFormationResourceProviderCIRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "codebuild-${GitHubRepositoryName}-ci-role"
+      RoleName: !Sub "codebuild-${GitHubRepositoryShortName}-ci"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -98,7 +101,7 @@ Resources:
             GitCloneDepth: 1
             SourceIdentifier: JAVA_PLUGIN
           - Type: S3
-            Location: !Ref CFNSDKBucket
+            Location: !Sub "${CFNSDKBucket}/"
             SourceIdentifier: SDK
       ServiceRole: !GetAtt AWSCloudFormationResourceProviderCIRole.Arn
       Triggers:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

#15 introduced some CI fixes but did not update the live stack with the template changes. There was a minor defect in the SDK path that couldn't be provisioned by CFN. I've fixed that and sync'd the stack.

Also (unnecessarily) added the `GitHubRepositoryShortName` argument to this stack for consistency across resource provider repos and updated the CI Role name for the same reason.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
