### PR TITLE
Update sourceUrl to HTTPS due to register service validation rule

### DIFF
--- a/aws-ses-configurationset/aws-ses-configurationset.json
+++ b/aws-ses-configurationset/aws-ses-configurationset.json
@@ -1,7 +1,7 @@
 {
     "typeName": "AWS::SES::ConfigurationSet",
     "description": "Resource schema for AWS::SES::ConfigurationSet.",
-    "sourceUrl": "git@github.com:aws-cloudformation/aws-cloudformation-resource-providers-ses.git",
+    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ses.git",
     "properties": {
         "Name": {
             "description": "The name of the configuration set.",

--- a/aws-ses-receiptfilter/aws-ses-receiptfilter.json
+++ b/aws-ses-receiptfilter/aws-ses-receiptfilter.json
@@ -1,7 +1,7 @@
 {
     "typeName": "AWS::SES::ReceiptFilter",
     "description": "Specify a new IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the Amazon SES Developer Guide.",
-    "sourceUrl": "git@github.com:aws-cloudformation/aws-cloudformation-resource-providers-ses.git",
+    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ses.git",
     "properties": {
         "Filter": {
             "description": "A data structure that describes the IP address filter that you want to specify. This structure consists of a name, an IP address range, and whether to allow or block mail from it.",


### PR DESCRIPTION
*Issue #, if available:* N/A

## Description of changes
RegisterService is changed to use the sourceUrl from the package. And the register service requires sourceUrl to be `https` protocol only.

This fix will update the sourceUrl in the schema to use https. In long term, we should discuss to whether support `git` protocol as URL in the source URL.

## Testing
__Before__
```
aws uluru describe-type-registration --registration-token 660b7c7d-1c05-4880-b6c6-5aa41c144d1a --region us-west-2
{
    "ProgressStatus": "FAILED",
    "Description": "Resource deployment is in ResourceDeploymentFinishingStage, currently in status FAILED. \nDeployment failed with exception: com.amazonaws.providerruntime.utils.exceptions.TerminalException with error msg : [660b7c7d-1c05-4880-b6c6-5aa41c144d1a] 1 validation error detected: Value 'git@github.com:aws-cloudformation/aws-cloudformation-resource-providers-ses.git' at 'sourceUrl' failed to satisfy constraint: Member must satisfy regular expression pattern: ^https\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z])(\\:[0-9]*)*([\\?/#].*)?$"
}
```

__After__
```
aws uluru describe-type-registration --registration-token 92187282-8308-460f-9bb0-ef0b4b91f234  --region us-west-2
{
    "ProgressStatus": "COMPLETE",
    "Description": "Resource deployment is in ResourceDeploymentFinishingStage, currently in status COMPLETE. \n",
    "TypeArn": "arn:aws:cloudformation:us-west-2:576483741303:type/resource/AWS-SES-ConfigurationSet",
    "TypeVersionArn": "arn:aws:cloudformation:us-west-2:576483741303:type/resource/AWS-SES-ConfigurationSet/00000001"
}
```






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
