### PR TITLE
Add handlers to ConfigurationSet schema json

### DIFF
--- a/aws-ses-configurationset/aws-ses-configurationset.json
+++ b/aws-ses-configurationset/aws-ses-configurationset.json
@@ -20,6 +20,7 @@
     "handlers": {
         "create": {
             "permissions": [
+                "ses:DescribeConfigurationSet",
                 "ses:CreateConfigurationSet"
             ]
         },
@@ -30,6 +31,7 @@
         },
         "delete": {
             "permissions": [
+                "ses:DescribeConfigurationSet",
                 "ses:DeleteConfigurationSet"
             ]
         },


### PR DESCRIPTION

*Issue #, if available:*  N/A

## Description
Due to this change(https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/pull/152), Java plugin will use `handlers` in the schema, otherwise, default will be empty.

This PR will add all handlers except `update`, because ConfigurationSet is not updatable.


## Testing
`mvn package`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
