### PR TITLE
Delete handler to fail on resource not found

### DIFF
--- a/aws-ses-configurationset/src/main/java/com/aws/ses/configurationset/DeleteHandler.java
+++ b/aws-ses-configurationset/src/main/java/com/aws/ses/configurationset/DeleteHandler.java
@@ -48,9 +48,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             logger.log(String.format("%s [%s] deleted successfully",
                 ResourceModel.TYPE_NAME, getPrimaryIdentifier(model).toString()));
         } catch (final ConfigurationSetDoesNotExistException e) {
-            logger.log(String.format("%s [%s] is already deleted",
-                ResourceModel.TYPE_NAME, getPrimaryIdentifier(model).toString()));
-            return ProgressEvent.defaultSuccessHandler(null);
+            throw new ResourceNotFoundException(ResourceModel.TYPE_NAME, model.getName());
         }
 
         CallbackContext stabilizationContext = CallbackContext.builder()

--- a/aws-ses-configurationset/src/test/java/com/aws/ses/configurationset/DeleteHandlerTest.java
+++ b/aws-ses-configurationset/src/test/java/com/aws/ses/configurationset/DeleteHandlerTest.java
@@ -216,15 +216,8 @@ public class DeleteHandlerTest {
             .desiredResourceState(model)
             .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isNull();
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertThrows(com.amazonaws.cloudformation.exceptions.ResourceNotFoundException.class, () -> {
+            handler.handleRequest(proxy, request, null, logger);
+        });
     }
 }

--- a/aws-ses-configurationset/template.yml
+++ b/aws-ses-configurationset/template.yml
@@ -1,0 +1,23 @@
+
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template for the AWS::SES::ConfigurationSet resource type
+
+Globals:
+  Function:
+    Timeout: 60  # docker start-up times can be long for SAM CLI
+
+Resources:
+  TypeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.aws.ses.configurationset.HandlerWrapper::handleRequest
+      Runtime: java8
+      CodeUri: ./target/aws-ses-configurationset-handler-1.0-SNAPSHOT.jar
+
+  TestEntrypoint:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.aws.ses.configurationset.HandlerWrapper::testEntrypoint
+      Runtime: java8
+      CodeUri: ./target/aws-ses-configurationset-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
*Issue #9 *

*Updated delete handler to fail when resource not found*

handler_create.py::contract_create_delete PASSED                                                                                                                                                                        [ 11%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                     [ 22%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                  [ 33%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                  [ 44%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                          [ 55%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                          [ 66%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                        [ 77%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                        [ 88%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                     [100%]

========================================================================================== 9 passed, 3 deselected in 823.97 seconds ===========================================================================================


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
