### PR TITLE
Removing initial read call from handler on CREATE

### DIFF
--- a/aws-ses-configurationset/aws-ses-configurationset.json
+++ b/aws-ses-configurationset/aws-ses-configurationset.json
@@ -20,7 +20,6 @@
     "handlers": {
         "create": {
             "permissions": [
-                "ses:DescribeConfigurationSet",
                 "ses:CreateConfigurationSet"
             ]
         },
@@ -31,7 +30,6 @@
         },
         "delete": {
             "permissions": [
-                "ses:DescribeConfigurationSet",
                 "ses:DeleteConfigurationSet"
             ]
         },

--- a/aws-ses-configurationset/resource-role.yaml
+++ b/aws-ses-configurationset/resource-role.yaml
@@ -23,10 +23,10 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                - "ses:ListConfigurationSets"
                 - "ses:CreateConfigurationSet"
                 - "ses:DeleteConfigurationSet"
                 - "ses:DescribeConfigurationSet"
+                - "ses:ListConfigurationSets"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-ses-configurationset/src/main/java/software/amazon/ses/configurationset/CreateHandler.java
+++ b/aws-ses-configurationset/src/main/java/software/amazon/ses/configurationset/CreateHandler.java
@@ -45,14 +45,6 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             );
         }
 
-        // pre-creation read to ensure no existing resource exists
-        try {
-            new ReadHandler().handleRequest(proxy, request, null, logger);
-            throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, model.getName());
-        } catch (final CfnNotFoundException e) {
-            // no existing resource, creation can proceed
-        }
-
         final CreateConfigurationSetRequest createConfigurationSetRequest =
                 CreateConfigurationSetRequest.builder()
                     .configurationSet(ConfigurationSet.builder()

--- a/aws-ses-configurationset/src/test/java/software/amazon/ses/configurationset/CreateHandlerTest.java
+++ b/aws-ses-configurationset/src/test/java/software/amazon/ses/configurationset/CreateHandlerTest.java
@@ -49,15 +49,6 @@ public class CreateHandlerTest {
         final CreateConfigurationSetResponse createResponse = CreateConfigurationSetResponse.builder()
             .build();
 
-        // throw for pre-describe and then return response for create
-        doThrow(ConfigurationSetDoesNotExistException.class)
-        .doReturn(createResponse)
-            .when(proxy)
-            .injectCredentialsAndInvokeV2(
-                any(),
-                any()
-            );
-
         final ResourceModel model = ResourceModel.builder()
             .name("test-set")
             .build();
@@ -81,9 +72,7 @@ public class CreateHandlerTest {
     public void handleRequest_FailedCreate_UnknownError() {
         final CreateHandler handler = new CreateHandler();
 
-        // throw for pre-describe and then throw arbitrary error which should propagate to be handled by wrapper
-        doThrow(ConfigurationSetDoesNotExistException.class)
-        .doThrow(SdkException.builder().message("test error").build())
+        doThrow(SdkException.builder().message("test error").build())
             .when(proxy)
             .injectCredentialsAndInvokeV2(
                 any(),
@@ -107,9 +96,7 @@ public class CreateHandlerTest {
     public void handleRequest_FailedCreate_AmazonServiceException() {
         final CreateHandler handler = new CreateHandler();
 
-        // AmazonServiceExceptions should be thrown so they can be handled by wrapper
-        doThrow(ConfigurationSetDoesNotExistException.class)
-            .doThrow(new AmazonServiceException("test error"))
+        doThrow(new AmazonServiceException("test error"))
             .when(proxy)
             .injectCredentialsAndInvokeV2(
                 any(),
@@ -133,38 +120,6 @@ public class CreateHandlerTest {
     public void handleRequest_FailedPreExisting() {
         final CreateHandler handler = new CreateHandler();
 
-        final ConfigurationSet set = ConfigurationSet.builder().name("test-set").build();
-        final DescribeConfigurationSetResponse describeResponse = DescribeConfigurationSetResponse.builder()
-            .configurationSet(set)
-            .build();
-
-        doReturn(describeResponse)
-            .when(proxy)
-            .injectCredentialsAndInvokeV2(
-                any(),
-                any()
-            );
-
-        final ResourceModel model = ResourceModel.builder()
-            .name("test-set")
-            .build();
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-            .desiredResourceState(model)
-            .build();
-
-        assertThrows(CfnAlreadyExistsException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
-    }
-
-    @Test
-    public void handleRequest_FailedPreExisting_AfterDescribeCheck() {
-        final CreateHandler handler = new CreateHandler();
-
-        // doesn't exist when we check, but timing wins the day and it exists after create
-        doThrow(ConfigurationSetDoesNotExistException.class).when(proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeConfigurationSetRequest.class), any());
         doThrow(ConfigurationSetAlreadyExistsException.class).when(proxy)
                 .injectCredentialsAndInvokeV2(any(CreateConfigurationSetRequest.class), any());
 
@@ -185,8 +140,6 @@ public class CreateHandlerTest {
     public void handleRequest_FailWith_InvalidConfigurationSetException() {
         final CreateHandler handler = new CreateHandler();
 
-        doThrow(ConfigurationSetDoesNotExistException.class).when(proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeConfigurationSetRequest.class), any());
         doThrow(InvalidConfigurationSetException.class).when(proxy)
                 .injectCredentialsAndInvokeV2(any(CreateConfigurationSetRequest.class), any());
 
@@ -207,8 +160,6 @@ public class CreateHandlerTest {
     public void handleRequest_FailWith_LimitExceededException() {
         final CreateHandler handler = new CreateHandler();
 
-        doThrow(ConfigurationSetDoesNotExistException.class).when(proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeConfigurationSetRequest.class), any());
         doThrow(LimitExceededException.class).when(proxy)
                 .injectCredentialsAndInvokeV2(any(CreateConfigurationSetRequest.class), any());
 
@@ -231,15 +182,6 @@ public class CreateHandlerTest {
 
         final CreateConfigurationSetResponse createResponse = CreateConfigurationSetResponse.builder()
             .build();
-
-        // throw for pre-describe and then return response for create
-        doThrow(ConfigurationSetDoesNotExistException.class)
-            .doReturn(createResponse)
-            .when(proxy)
-            .injectCredentialsAndInvokeV2(
-                any(),
-                any()
-            );
 
         // no name supplied; should be generated
         final ResourceModel model = ResourceModel.builder().build();

--- a/aws-ses-configurationset/template.yml
+++ b/aws-ses-configurationset/template.yml
@@ -11,13 +11,13 @@ Resources:
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: com.aws.ses.configurationset.HandlerWrapper::handleRequest
+      Handler: software.amazon.ses.configurationset.HandlerWrapper::handleRequest
       Runtime: java8
       CodeUri: ./target/aws-ses-configurationset-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: com.aws.ses.configurationset.HandlerWrapper::testEntrypoint
+      Handler: software.amazon.ses.configurationset.HandlerWrapper::testEntrypoint
       Runtime: java8
       CodeUri: ./target/aws-ses-configurationset-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
*Issue #, if available:* #34 

*Description of changes:* This removes the call to the read handler before creating a resource. We can safely rely on the ConfigurationSetAlreadyExists exception being thrown when creating configuration sets.

```
(env) 88e9fe53e427:aws-ses-configurationset jotompki$ cfn test -vv
Logging set up successfully
Running test: Namespace(command=<function test at 0x103cb77b8>, endpoint='http://127.0.0.1:3001', function_name='TestEntrypoint', passed_to_pytest=[], region='us-east-1', role_arn=None, subparser_name='test', verbose=2, version=False)
Root directory: /Users/jotompki/workplace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset
Loading project file '/Users/jotompki/workplace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.rpdk-config'
Validating your resource specification...
Rewriting refs in '<BASE>' (file:///Users/jotompki/workplace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/aws-ses-configurationset.json)
Override file '/Users/jotompki/workplace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/overrides.json' not found. No overrides will be applied
temporary pytest.ini path: /var/folders/w_/842t19210v7fhhmlq5mlh_cjj90hb8/T/pytest_oc9dzr_9.ini
pytest args: ['-c', '/private/var/folders/w_/842t19210v7fhhmlq5mlh_cjj90hb8/T/pytest_oc9dzr_9.ini', '-m', 'not update']
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.7.0, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /Users/jotompki/workplace/rpdk/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/jotompki/workplace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Users/jotompki/workplace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/w_/842t19210v7fhhmlq5mlh_cjj90hb8/T/pytest_oc9dzr_9.ini
plugins: hypothesis-4.44.2, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 12 items / 3 deselected / 9 selected                                                                                                                                                 

handler_create.py::contract_create_delete PASSED                                                                                                                                         [ 11%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                      [ 22%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                   [ 33%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                   [ 44%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                           [ 55%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                           [ 66%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                         [ 77%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                         [ 88%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                      [100%]

======================================================================================= warnings summary =======================================================================================
handler_create.py::contract_create_delete
handler_create.py::contract_create_duplicate
handler_delete.py::contract_delete_read
  /Users/jotompki/workplace/rpdk/env/lib/python3.7/site-packages/hypothesis/searchstrategy/strategies.py:286: NonInteractiveExampleWarning: The `.example()` method is good for exploring strategies, but should only be used interactively.  We recommend using `@given` for tests - it performs better, saves and replays failures to avoid flakiness, and reports minimal examples. (strategy: fixed_dictionaries({'Name': from_regex(regex='^[a-zA-Z0-9_-]{0,64}\\Z')}))
    NonInteractiveExampleWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================================================== 9 passed, 3 deselected, 3 warnings in 365.73 seconds =====================================================================
Finished test
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
