### PR TITLE
Enforce a minimum length of 1 on Name property

### DIFF
--- a/aws-ses-configurationset/aws-ses-configurationset.json
+++ b/aws-ses-configurationset/aws-ses-configurationset.json
@@ -6,8 +6,9 @@
         "Name": {
             "description": "The name of the configuration set.",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]{0,64}$",
-            "maxLength": 64
+            "pattern": "^[a-zA-Z0-9_-]{1,64}$",
+            "maxLength": 64,
+            "minLength": 1
         }
     },
     "createOnlyProperties": [


### PR DESCRIPTION
*Description of changes:*

Enforce a minimum length of 1 on Name property, otherwise the following error occurs:

```
The configuration set name must be specified. (Service: AmazonSimpleEmailService; Status Code: 400; Error Code: InvalidParameterValue; Request ID: ...)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
